### PR TITLE
fix: TagContainer#delete の無限再帰を修正 (Ruby 4.0 対応, v1.8.24)

### DIFF
--- a/config/lib.yaml
+++ b/config/lib.yaml
@@ -36,7 +36,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/ginseng-fediverse
-  version: 1.8.23
+  version: 1.8.24
 parser:
   note:
     url:

--- a/lib/ginseng/fediverse/tag_container.rb
+++ b/lib/ginseng/fediverse/tag_container.rb
@@ -31,7 +31,11 @@ module Ginseng
       alias body text
 
       def delete(tag)
-        reject! {|v| v.casecmp(tag).zero?}
+        matches = filter {|v| v.casecmp(tag).zero?}
+        return nil if matches.empty?
+        matches.each {|v| super(v)}
+        @tags = nil
+        return self
       end
 
       def text=(text)

--- a/test/tag_container_test.rb
+++ b/test/tag_container_test.rb
@@ -55,6 +55,39 @@ module Ginseng
       def test_scan
         assert_equal(TagContainer.scan('#フワ #プルンス'), Set['フワ', 'プルンス'])
       end
+
+      def test_delete
+        @container.push('実況')
+        @container.push('precure_fun')
+
+        assert_equal(@container.delete('実況'), @container)
+        assert_equal(Set['precure_fun'], @container)
+      end
+
+      def test_delete_case_insensitive
+        @container.push('Makoto')
+        @container.push('precure_fun')
+
+        assert_equal(@container.delete('MAKOTO'), @container)
+        assert_equal(Set['precure_fun'], @container)
+      end
+
+      def test_delete_missing
+        @container.push('precure_fun')
+
+        assert_nil(@container.delete('実況'))
+        assert_equal(Set['precure_fun'], @container)
+      end
+
+      def test_select_bang_with_short_tags
+        @container.push('実況')
+        @container.push('precure_fun')
+
+        assert_nothing_raised do
+          @container.select! {|v| v.to_s.length > 2}
+        end
+        assert_equal(Set['precure_fun'], @container)
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary

- Ruby 4.0 (set 1.x) で `Set#reject!` が `delete_if` 経由で `Set#delete` を呼ぶ実装に変わったため、TagContainer の `delete` override が再帰し SystemStackError になっていた
- 影響: 上流の `select!`/`reject!`/`delete_if` 等のフィルタ操作で、削除対象が1件でも存在すると無限再帰 → SystemStackError。本クラスを利用している tomato-shrieker / mulukhiya 等で短いタグ運用時にサイレント失敗の原因になっていた
- 修正: `filter` で対象要素を配列に取り出して `super` (Set#delete) を直接呼ぶことで再帰解消。Set#delete のセマンティクス (見つからなければ nil、削除したら self) を維持

## Test plan

- [x] `bundle exec rake test` 全 53 件パス
- [x] 既存のテストに加え、TagContainer#delete のリグレッションテスト 4 件を追加 (case-sensitive/insensitive、欠落時 nil、`select!` 経由の短タグ削除がエラーにならないこと)
- [ ] 取り込み先 (tomato-shrieker / mulukhiya 等) で実環境動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)