### PR TITLE
fix: #241 TootURI が Mastodon の numeric_ap_id 形式 (/ap/users/<id>/statuses/<id>) を解釈できるようにする

### DIFF
--- a/config/lib.yaml
+++ b/config/lib.yaml
@@ -36,7 +36,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/ginseng-fediverse
-  version: 1.8.24
+  version: 1.8.25
 parser:
   note:
     url:
@@ -61,6 +61,7 @@ parser:
         - ^/web/statuses/([[:digit:]]+)
         - ^/@[[:word:]]+/([[:digit:]]+)
         - ^/users/[[:word:]]+/statuses/([[:digit:]]+)
+        - ^/ap/users/[[:digit:]]+/statuses/([[:digit:]]+)
         - ^/notice/([[:word:]]+)
     visibility:
       direct:

--- a/test/toot_uri_test.rb
+++ b/test/toot_uri_test.rb
@@ -1,0 +1,30 @@
+module Ginseng
+  module Fediverse
+    class TootURITest < TestCase
+      # parser/toot/url/patterns の各形式から toot_id を抽出できることを確認する。
+      # 末尾の numeric_ap_id 形式 (/ap/users/<id>/statuses/<id>) は現代 Mastodon の
+      # 既定 (#241)。
+      def test_toot_id
+        {
+          'https://mstdn.example.com/web/statuses/123' => 123,
+          'https://mstdn.example.com/@pooza/456' => 456,
+          'https://mstdn.example.com/users/pooza/statuses/789' => 789,
+          'https://mstdn.example.com/ap/users/116701601341929545/statuses/116701682233818969' =>
+            116_701_682_233_818_969,
+        }.each do |url, id|
+          uri = TootURI.parse(url)
+
+          assert_equal(id, uri.toot_id, url)
+          assert_predicate(uri, :valid?, url)
+        end
+      end
+
+      def test_toot_id_unmatched
+        uri = TootURI.parse('https://mstdn.example.com/about/more')
+
+        assert_nil(uri.toot_id)
+        assert_false(uri.valid?)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## 概要

現代 Mastodon は新規ローカルアカウントの ActivityPub URI を **`/ap/users/<account_id>/statuses/<id>`**（数値アカウント ID）形式で生成する（`Account#id_scheme` の既定が `numeric_ap_id`）。

既存の `parser/toot/url/patterns` は `/users/<username>/statuses/` までしか対応しておらず、`TootURI#toot_id` が nil → `valid?` false。利用側 (mulukhiya-toot-proxy 等) で**ローカル status の `url` カラムが null の場合に `status.uri` が nil**になっていた（本番影響）。

## 変更

- **config/lib.yaml**: toot patterns に `^/ap/users/[[:digit:]]+/statuses/([[:digit:]]+)` を 1 行追加
- **test/toot_uri_test.rb**: 各 URL 形式 (web / @user / users / ap-users) から `toot_id` を抽出できることのテストを新設（numeric_ap_id 含む）
- version `1.8.24` → `1.8.25`

## 検証

- `bundle exec rake test`: **55 tests / 162 assertions / 0 failures**
- negative check: 追加パターンを外すと `test_toot_id` が numeric_ap_id ケースで失敗することを確認（テストが有効）
- 発見時の mulukhiya 実機 harness テストも本修正で全緑（#241 本文の検証記録どおり）

## スコープ外（要検討）

`TootURI#account_id`（`^/users/<username>/statuses/`、`publicize!`/`local?` 用）の `/ap/users/` 対応は、**数値 ID から `/@<username>/` を復元できない**ため別途検討とする。現状 `account_id` は nil を返し `publicize!` は no-op（誤った `/@<数値>/` を生成しない）で安全側。

## 関連
- 発見経緯: pooza/mulukhiya-toot-proxy#4379（chubo2 fedi-test-harness 実機テスト）
- pooza/chubo2#48

🤖 Generated with [Claude Code](https://claude.com/claude-code)