### PR TITLE
fix: nodeinfo の contact_account nil と numeric_ap_id の publicize を是正 (#238 / #243)

### DIFF
--- a/config/lib.yaml
+++ b/config/lib.yaml
@@ -36,7 +36,7 @@ package:
     - tkoishi@b-shock.co.jp
   license: MIT
   url: https://github.com/pooza/ginseng-fediverse
-  version: 1.8.25
+  version: 1.8.26
 parser:
   note:
     url:

--- a/lib/ginseng/fediverse/service/mastodon_service.rb
+++ b/lib/ginseng/fediverse/service/mastodon_service.rb
@@ -6,16 +6,23 @@ module Ginseng
       def nodeinfo
         unless @nodeinfo
           @nodeinfo = http.get('/api/v1/instance').parsed_response.merge(super)
-          contact = @nodeinfo['contact_account']
           @nodeinfo['metadata'] = {
             'nodeName' => @nodeinfo['title'],
-            'maintainer' => {
-              'name' => contact['display_name'] || contact['username'],
-              'email' => @nodeinfo['email'],
-            },
+            'maintainer' => maintainer,
           }
         end
         return @nodeinfo
+      end
+
+      # 管理画面で連絡先アカウントが未設定のインスタンスでは contact_account が
+      # nil になる。以前はここで NoMethodError になり nodeinfo 全体が取れなかった
+      # (#238)。email だけは instance API から取れるので、名前のみ落として返す。
+      def maintainer
+        contact = @nodeinfo['contact_account']
+        return {
+          'name' => contact && (contact['display_name'].presence || contact['username']),
+          'email' => @nodeinfo['email'],
+        }
       end
 
       alias info nodeinfo

--- a/lib/ginseng/fediverse/uri/toot_uri.rb
+++ b/lib/ginseng/fediverse/uri/toot_uri.rb
@@ -21,17 +21,42 @@ module Ginseng
 
       alias id toot_id
 
+      ACCOUNT_ID_PATTERNS = [
+        %r{^/users/([[:word:]]+)/statuses/[[:digit:]]+}i,
+        %r{^/ap/users/([[:digit:]]+)/statuses/[[:digit:]]+}i,
+      ].freeze
+
+      # path に現れるアカウント識別子。`/users/<username>/` では username を、
+      # numeric_ap_id 形式 `/ap/users/<id>/` では数値 ID を返す (#243)。
       def account_id
-        return nil unless matches = %r{^/users/([[:word:]]+)/statuses/[[:digit:]]+}i.match(path)
-        return matches[1]
+        ACCOUNT_ID_PATTERNS.each do |pattern|
+          next unless matches = pattern.match(path)
+          return matches[1]
+        end
+        return nil
+      end
+
+      # 公開 URL `/@<username>/<id>` を組み立てられる場合の username。
+      # numeric_ap_id 形式では数値 ID しか分からず、`/@` は username を前提と
+      # するため nil を返す。
+      def account_username
+        id = account_id
+        return nil if id.nil? || id.match?(/^[[:digit:]]+$/)
+        return id
       end
 
       def valid?
         return absolute? && id.present?
       end
 
+      # 公開 Web URL 形式へ書き換える。
+      #
+      # ⚠ numeric_ap_id 形式 `/ap/users/<id>/statuses/<id>` は no-op。数値 ID から
+      # username を解くには API 往復が要り、publicize はフィード生成の per-link
+      # 経路から呼ばれるためここではネットワークを踏まない。誤った `/@<数値 ID>/`
+      # を作るくらいなら AP 形式のまま返す (#243)。
       def publicize!
-        self.path = "/@#{account_id}/#{toot_id}" if account_id && toot_id
+        self.path = "/@#{account_username}/#{toot_id}" if account_username && toot_id
         return self
       end
 

--- a/test/mastodon_service_nodeinfo_test.rb
+++ b/test/mastodon_service_nodeinfo_test.rb
@@ -1,0 +1,41 @@
+module Ginseng
+  module Fediverse
+    # nodeinfo の metadata 組み立て。連絡先アカウント未設定のインスタンスで
+    # NoMethodError にならないこと (#238)。
+    class MastodonServiceNodeinfoTest < TestCase
+      def create_service(nodeinfo)
+        service = MastodonService.new(Ginseng::URI.parse('https://mstdn.example.com/'))
+        service.instance_variable_set(:@nodeinfo, nodeinfo)
+        return service
+      end
+
+      def test_maintainer_with_contact_account
+        service = create_service(
+          'email' => 'admin@example.com',
+          'contact_account' => {'display_name' => 'ぷぅざ', 'username' => 'pooza'},
+        )
+
+        assert_equal('ぷぅざ', service.maintainer['name'])
+        assert_equal('admin@example.com', service.maintainer['email'])
+      end
+
+      def test_maintainer_falls_back_to_username
+        service = create_service(
+          'email' => 'admin@example.com',
+          'contact_account' => {'display_name' => '', 'username' => 'pooza'},
+        )
+
+        assert_equal('pooza', service.maintainer['name'])
+      end
+
+      # 管理画面で連絡先アカウントが未設定なら contact_account が nil になる。
+      # 以前はここで NoMethodError になり nodeinfo 全体が取れなかった。
+      def test_maintainer_without_contact_account
+        service = create_service('email' => 'admin@example.com')
+
+        assert_nil(service.maintainer['name'])
+        assert_equal('admin@example.com', service.maintainer['email'])
+      end
+    end
+  end
+end

--- a/test/toot_uri_test.rb
+++ b/test/toot_uri_test.rb
@@ -19,6 +19,33 @@ module Ginseng
         end
       end
 
+      def test_account_id
+        {
+          'https://mstdn.example.com/users/pooza/statuses/789' => 'pooza',
+          'https://mstdn.example.com/ap/users/116701601341929545/statuses/116701682233818969' =>
+            '116701601341929545',
+          'https://mstdn.example.com/@pooza/456' => nil,
+        }.each do |url, id|
+          assert_equal(id, TootURI.parse(url).account_id, url)
+        end
+      end
+
+      # publicize! が `/@<username>/<id>` を作れるのは username が分かる形式だけ。
+      def test_publicize
+        uri = TootURI.parse('https://mstdn.example.com/users/pooza/statuses/789').publicize
+
+        assert_equal('/@pooza/789', uri.path)
+      end
+
+      # numeric_ap_id 形式は no-op。`/@<数値 ID>/` という誤った公開 URL を作らない (#243)。
+      def test_publicize_leaves_numeric_ap_id_untouched
+        url = 'https://mstdn.example.com/ap/users/116701601341929545/statuses/116701682233818969'
+        uri = TootURI.parse(url).publicize
+
+        assert_equal('/ap/users/116701601341929545/statuses/116701682233818969', uri.path)
+        assert_nil(uri.account_username)
+      end
+
       def test_toot_id_unmatched
         uri = TootURI.parse('https://mstdn.example.com/about/more')
 


### PR DESCRIPTION
Closes #238
Closes #243

## #238 contact_account が nil のとき NoMethodError

管理画面で連絡先アカウントが未設定のインスタンスでは `contact_account` が nil になり、`nodeinfo` 全体が取れなくなっていた。`maintainer` を切り出して nil を許容し、email だけは instance API から取れるので名前のみ落として返す。`display_name` が空文字列のときに `username` へ倒れる挙動も明示した（`||` では空文字列が truthy で拾えていなかった）。

## #243 numeric_ap_id 形式の account_id / publicize!

Issue に挙がっていた 3 案のうち **1 と 2 を組み合わせた**。

- `account_id` は `/ap/users/<id>/statuses/<id>` でもマッチし、**数値 ID** を返す。
- 新設の `account_username` は「`/@<username>/<id>` を組み立てられる場合の username」だけを返す（数値なら nil）。
- `publicize!` は `account_username` を見るため、numeric_ap_id 形式では **no-op**。

案 3（`fetch_status` の `url` を使う）は採らなかった。`publicize` はフィード生成の per-link 経路から呼ばれるため、ここでネットワーク往復を足すとリンク数に比例してレイテンシが乗る。**誤った `/@<数値 ID>/` を作るくらいなら AP 形式のまま返す**という判断で、この挙動をコメントと回帰テストで固定した。

AP 形式 URL がフィードに残ること自体は解消していない。実害が観測されたら別途扱う。

## 検証

`rake test` 55 tests → 61 tests、0 failures / 0 errors。